### PR TITLE
Method to reset the seeding of a stage

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -94,6 +94,23 @@ export class Update {
      * @param seeding The new seeding.
      */
     public async seeding(stageId: number, seeding: Seeding | SeedingIds) {
+        return this.updateSeeding(stageId, seeding);
+    }
+
+    /**
+     * Resets the seeding of a stage.
+     * @param stageId ID of the stage.
+     */
+    public async resetSeeding(stageId: number) {
+        return this.updateSeeding(stageId, null);
+    }
+
+    /**
+     * Updates or resets the seeding of a stage.
+     * @param stageId ID of the stage.
+     * @param seeding A new seeding or null to reset the existing seeding.
+     */
+    private async updateSeeding(stageId: number, seeding: Seeding | SeedingIds | null) {
         const stage = await this.storage.select<Stage>('stage', stageId);
         if (!stage) throw Error('Stage not found.');
 
@@ -102,7 +119,7 @@ export class Update {
             tournamentId: stage.tournament_id,
             type: stage.type,
             settings: stage.settings,
-            seeding,
+            seeding: seeding || undefined,
         }, true);
 
         const method = this.getSeedingOrdering(stage.type, create);
@@ -110,7 +127,7 @@ export class Update {
 
         const matches = await this.getSeedingMatches(stage.id, stage.type);
         if (!matches)
-            throw Error('Error getting first matches.');
+            throw Error('Error getting matches associated to the seeding.');
 
         const ordered = ordering[method](slots);
         await this.assertCanUpdateSeeding(matches, ordered);

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -337,6 +337,20 @@ describe('Seeding', () => {
         assert.equal((await storage.select('participant')).length, 8);
     });
 
+    it('should reset the seeding of a stage', async () => {
+        await manager.update.seeding(0, [
+            'Team 1', 'Team 2',
+            'Team 3', 'Team 4',
+            'Team 5', 'Team 6',
+            'Team 7', 'Team 8',
+        ]);
+
+        await manager.update.resetSeeding(0);
+
+        assert.equal((await storage.select('match', 0)).opponent1.id, null);
+        assert.equal((await storage.select('participant')).length, 8); // Participants aren't removed.
+    });
+
     it('should update the seeding in a stage with participants already', async () => {
         await manager.update.seeding(0, [
             'Team 1', 'Team 2',


### PR DESCRIPTION
This PR adds a method to reset the seeding of a stage. It will use the size of the stage stored in the database to set the slots back to "To be determined" (null id).