### PR TITLE
Initial import functionality

### DIFF
--- a/src/storage/json.ts
+++ b/src/storage/json.ts
@@ -1,5 +1,5 @@
 import { JsonDB } from 'node-json-db';
-import { CrudInterface, Table } from '../types';
+import { CrudInterface, StageData, Table } from '../types';
 
 const clone = require('rfdc')();
 
@@ -243,6 +243,18 @@ export class JsonDatabase implements CrudInterface {
         const predicate = this.makeFilter(filter);
 
         this.internal.push(path, values.filter(value => !predicate(value)));
+        return true;
+    }
+
+    /**
+     * Delete data in a table, based on a filter.
+     *
+     * @param data Where to delete in.
+     */
+    public async import(data: StageData): Promise<boolean> {
+        if (!data) return false;
+
+        this.internal.resetData(data)
         return true;
     }
 }

--- a/src/storage/json.ts
+++ b/src/storage/json.ts
@@ -247,14 +247,14 @@ export class JsonDatabase implements CrudInterface {
     }
 
     /**
-     * Delete data in a table, based on a filter.
+     * Imports given data and replaces the current bracket database.
      *
-     * @param data Where to delete in.
+     * @param data Data to import.
      */
     public async import(data: StageData): Promise<boolean> {
         if (!data) return false;
 
-        this.internal.resetData(data)
+        this.internal.resetData(data);
         return true;
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,9 +140,9 @@ export interface CrudInterface {
     delete<T>(table: Table, filter: Partial<T>): Promise<boolean>
 
     /**
-     * Import given stage data.
+     * Imports given data and replaces the current bracket database.
      *
-     * @param data Stage date to import
+     * @param data Data to import.
      */
     import(data: StageData): Promise<boolean>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,13 @@ export interface CrudInterface {
      * @param filter An object to filter data.
      */
     delete<T>(table: Table, filter: Partial<T>): Promise<boolean>
+
+    /**
+     * Import given stage data.
+     *
+     * @param data Stage date to import
+     */
+    import(data: StageData): Promise<boolean>
 }
 
 export interface Storage extends CrudInterface {

--- a/test/general.spec.js
+++ b/test/general.spec.js
@@ -718,4 +718,58 @@ describe('Reset match and match games', () => {
         assert.strictEqual((await storage.select('match', 6)).opponent1.result, undefined);
         assert.strictEqual((await storage.select('match', 7)).opponent1, null); // Still BYE in consolation final.
     });
+
+    it('should update storage with imported data', async () => {
+        await manager.create({
+            name: 'Example',
+            tournamentId: 0,
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+            settings: {
+                seedOrdering: ['natural'],
+            },
+        });
+
+        const group = await storage.select('group');
+        const match = await storage.select('match');
+        const match_game = await storage.select('match_game');
+        const participant = await storage.select('participant');
+        const round = await storage.select('round');
+        const stage = await storage.select('stage');
+
+        const initialBracketData = {
+            group,
+            match,
+            match_game,
+            participant,
+            round,
+            stage,
+        };
+
+        await manager.update.match({
+            id: 0,
+            opponent1: { score: 16, result: 'win' },
+            opponent2: { score: 12 },
+        });
+
+        await manager.update.match({
+            id: 1,
+            opponent1: { score: 16, result: 'win' },
+            opponent2: { score: 12 },
+        });
+
+        await manager.update.match({
+            id: 2,
+            opponent1: { score: 16, result: 'win' },
+            opponent2: { score: 12 },
+        });
+
+        assert.strictEqual((await storage.select('match', 0)).opponent1.result, 'win');
+        assert.strictEqual((await storage.select('match', 1)).opponent1.result, 'win');
+
+        await storage.import(initialBracketData);
+
+        assert.strictEqual((await storage.select('match', 0)).opponent1.result, undefined);
+        assert.strictEqual((await storage.select('match', 1)).opponent1.result, undefined);
+    });
 });


### PR DESCRIPTION
Hey there!

I had time to look more into the [import functionality](https://github.com/Drarig29/brackets-manager.js/issues/63) and here is a quick proposal for it.

This is just a quick implementation, and would be great if this could be merged in and publish before tomorrow! Don't stress about it too much, though, as I've prepared stuff on my end. I published my own fork with this addition as a GitHub NPM package, so I can use that one for my tournament for the time being.

Currently the function just resets the whole database we have created instead of a single bracket. If you wanted to reset/import a single bracket data, you'd have to pass in the full structure that includes all the other bracket data, too. 