### PR TITLE
Export all helpers in public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ As you can see, the [manager](https://drarig29.github.io/brackets-docs/reference
 
 You can navigate the API documentation here: [`BracketsManager` class documentation](https://drarig29.github.io/brackets-docs/reference/manager/classes/BracketsManager.html)
 
+You also have access to all of the helpers defined by the library (see [list of helpers here](https://drarig29.github.io/brackets-docs/reference/manager/modules/helpers.html)):
+
+```js
+const { helpers } = require('brackets-manager');
+```
+
 # Credits
 
 This library has been created to be used by the [Nantarena](https://nantarena.net/).

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { BracketsManager } from './manager';
+import * as helpers from './helpers';
 
 import {
     CrudInterface,
@@ -14,34 +15,6 @@ import {
     Table,
 } from './types';
 
-import {
-    getWinner,
-    getLoser,
-    getMatchResult,
-    isMatchStarted,
-    isMatchCompleted,
-    isMatchForfeitCompleted,
-    isMatchResultCompleted,
-    isMatchDrawCompleted,
-    isMatchWinCompleted,
-    isMatchByeCompleted,
-    isMatchUpdateLocked,
-    isMatchParticipantLocked,
-    hasBye,
-    getUpperBracketRoundCount,
-    getRoundPairCount,
-    getLoserRoundMatchCount,
-    getLoserRoundLoserCount,
-    getLowerBracketRoundCount,
-    getNearestPowerOfTwo,
-    minScoreToWinBestOfX,
-    isRoundRobin,
-    isWinnerBracket,
-    isLoserBracket,
-    isFinalGroup,
-    getMatchLocation,
-} from './helpers';
-
 export {
     BracketsManager,
     CrudInterface,
@@ -55,32 +28,5 @@ export {
     StandardBracketResults,
     Storage,
     Table,
-};
-
-export const helpers = {
-    getWinner,
-    getLoser,
-    getMatchResult,
-    isMatchStarted,
-    isMatchCompleted,
-    isMatchForfeitCompleted,
-    isMatchResultCompleted,
-    isMatchDrawCompleted,
-    isMatchWinCompleted,
-    isMatchByeCompleted,
-    isMatchUpdateLocked,
-    isMatchParticipantLocked,
-    hasBye,
-    getUpperBracketRoundCount,
-    getRoundPairCount,
-    getLoserRoundMatchCount,
-    getLoserRoundLoserCount,
-    getLowerBracketRoundCount,
-    getNearestPowerOfTwo,
-    minScoreToWinBestOfX,
-    isRoundRobin,
-    isWinnerBracket,
-    isLoserBracket,
-    isFinalGroup,
-    getMatchLocation,
+    helpers,
 };


### PR DESCRIPTION
Before this PR, only a selection of helpers was exported.

Now, we export all of them. Even the less useful ones. Because... who knows. (and because I won't have to maintain the list of exported helpers anymore 😅)