### PR TITLE
fix: `currentRound` returns round with only `Locked` and `Completed` matches

### DIFF
--- a/src/get.ts
+++ b/src/get.ts
@@ -109,7 +109,7 @@ export class Get extends BaseGetter {
         const matchesByRound = helpers.splitBy(matches, 'round_id');
 
         for (const roundMatches of matchesByRound) {
-            if (roundMatches.every(match => match.status >= Status.Completed))
+            if (roundMatches.every((match) => !helpers.isMatchOngoing(match)))
                 continue;
 
             const round = await this.storage.select('round', roundMatches[0].round_id);


### PR DESCRIPTION
Running the same example provided in the Issue will now yield the following result:
```typescript
import { BracketsManager } from 'brackets-manager';
import { JsonDatabase } from 'brackets-json-db';

const storage = new JsonDatabase();
const manager = new BracketsManager(storage);

async function main() {
  const stage = await manager.create.stage({
    name: 'Some Title',
    tournamentId: 0,
    type: 'single_elimination',
    seeding: ['P1', 'P2', 'P3', null],
    settings: {
      grandFinal: 'simple',
      balanceByes: true,
      matchesChildCount: 3,
    },
  });

  console.log(await manager.get.currentRound(stage.id));
  // { id: 0, number: 1, stage_id: 0, group_id: 0 }
  console.log(await manager.get.currentMatches(stage.id));
  // [
  //   {
  //     id: 1,
  //     number: 2,
  //     stage_id: 0,
  //     group_id: 0,
  //     round_id: 0,
  //     child_count: 3,
  //     status: 2,
  //     opponent1: { id: 1, position: 2 },
  //     opponent2: { id: 2, position: 3 }
  //   }
  // ]

  await manager.update.match({ id: 1, opponent1: { result: 'win' } });

  console.log(await manager.get.currentRound(stage.id));
  // This is now the expected Round and matches the `round_id`
  // of the current match.
  // { id: 1, number: 2, stage_id: 0, group_id: 0 }
  console.log(await manager.get.currentMatches(stage.id));
  // [
  //   {
  //     id: 2,
  //     number: 1,
  //     stage_id: 0,
  //     group_id: 0,
  //     round_id: 1,
  //     child_count: 3,
  //     status: 2,
  //     opponent1: { id: 0, position: undefined },
  //     opponent2: { id: 1, position: undefined },
  //   },
  // ];
}
main();
```

Reference #180 