### PR TITLE
Fix `inner_outer` ordering for >32 players

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
             },
         },
     ],
-    ignorePatterns: ['dist/', 'webpack.config.js'],
+    ignorePatterns: ['dist/', 'docs/', 'webpack.config.js'],
     extends: [
         'plugin:@typescript-eslint/recommended',
         'plugin:jsdoc/recommended',
@@ -42,6 +42,7 @@ module.exports = {
         'jsdoc/require-param-type': 0,
         'jsdoc/require-returns': 0,
         'jsdoc/require-returns-type': 0,
+        'jsdoc/check-param-names': 2,
 
         '@typescript-eslint/explicit-function-return-type': ['error'],
         '@typescript-eslint/no-empty-function': 0,

--- a/src/base/getter.ts
+++ b/src/base/getter.ts
@@ -147,7 +147,6 @@ export class BaseGetter {
      * Gets the matches leading to the given match, which is in a final group (grand final).
      *
      * @param match The current match.
-     * @param stage The parent stage.
      * @param roundNumber Number of the current round.
      */
     private async getPreviousMatchesFinalDoubleElimination(match: Match, roundNumber: number): Promise<Match[]> {

--- a/src/ordering.ts
+++ b/src/ordering.ts
@@ -14,42 +14,23 @@ export const ordering: OrderingMap = {
         return result;
     },
     'inner_outer': <T>(array: T[]) => {
-        if (array.length === 2)
-            return array;
+        if (array.length === 2) return array;
 
-        const size = array.length / 4;
+        const participantCount = array.length;
 
-        const innerPart = [array.slice(size, 2 * size), array.slice(2 * size, 3 * size)]; // [_, X, X, _]
-        const outerPart = [array.slice(0, size), array.slice(3 * size, 4 * size)]; // [X, _, _, X]
-
-        const methods = {
-            inner(part: T[][]): T[] {
-                return [part[0].pop()!, part[1].shift()!];
-            },
-            outer(part: T[][]): T[] {
-                return [part[0].shift()!, part[1].pop()!];
-            },
-        };
+        // Generate standard bracket seeding positions iteratively.
+        let positions: number[] = [1, 2];
+        while (positions.length < participantCount) {
+            const size = positions.length * 2;
+            const next: number[] = [];
+            for (const pos of positions)
+                next.push(pos, size + 1 - pos);
+            positions = next;
+        }
 
         const result: T[] = [];
-
-        /**
-         * Adds a part (inner or outer) of a part.
-         *
-         * @param part The part to process.
-         * @param method The method to use.
-         */
-        function add(part: T[][], method: 'inner' | 'outer'): void {
-            if (part[0].length > 0 && part[1].length > 0)
-                result.push(...methods[method](part));
-        }
-
-        for (let i = 0; i < size / 2; i++) {
-            add(outerPart, 'outer'); // Outer part's outer
-            add(innerPart, 'inner'); // Inner part's inner
-            add(outerPart, 'inner'); // Outer part's inner
-            add(innerPart, 'outer'); // Inner part's outer
-        }
+        for (const pos of positions)
+            result.push(array[pos - 1]);
 
         return result;
     },

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -65,6 +65,29 @@ describe('Helpers', () => {
             ]);
         });
 
+        it('should place 32 participants with inner-outer method', () => {
+            const teams = Array.from({ length: 32 }, (_, i) => i + 1);
+            const placement = ordering['inner_outer'](teams);
+            assert.deepStrictEqual(placement, [
+                1, 32,
+                16, 17,
+                8, 25,
+                9, 24,
+                4, 29,
+                13, 20,
+                5, 28,
+                12, 21,
+                2, 31,
+                15, 18,
+                7, 26,
+                10, 23,
+                3, 30,
+                14, 19,
+                6, 27,
+                11, 22,
+            ]);
+        });
+
         it('should make a natural ordering', () => {
             assert.deepStrictEqual(ordering['natural']([1, 2, 3, 4, 5, 6, 7, 8]), [1, 2, 3, 4, 5, 6, 7, 8]);
         });


### PR DESCRIPTION
Closes https://github.com/Drarig29/brackets-manager.js/issues/199

Fix the implementation with standard algorithm instead of custom one.