### PR TITLE
Rank standings by points if rank is the same

### DIFF
--- a/src/get.ts
+++ b/src/get.ts
@@ -314,7 +314,12 @@ export class Get extends BaseGetter {
             }));
         });
 
-        return unsortedRanking.sort((a, b) => a.rank - b.rank);
+        return unsortedRanking.sort((a, b) => {
+            // If the ranks are the same, sort by points.
+            // Points are compared in reverse order to get the highest points first.
+            if (a.rank === b.rank) return b.points - a.points;
+            return a.rank - b.rank;
+        });
     }
 
     /**


### PR DESCRIPTION
When getting the final standings of a round robin stage, if there are multiple participants that has the same rank inside the group but different points amounts, i think its better to rank them by the points.