### PR TITLE
Fix `update.seeding()` advancing TBD slots as BYE wins to next round

### DIFF
--- a/src/base/stage/creator.ts
+++ b/src/base/stage/creator.ts
@@ -90,7 +90,7 @@ export class StageCreator {
      * Enables the update mode.
      * 
      * @param stageId ID of the stage.
-     * @param enableByes Whether to use BYEs or TBDs for `null` values in an input seeding.
+     * @param enableByes Whether to use BYEs or TBDs for `null` values in an input seeding. Set to `true` when `confirmSeeding()` is called.
      */
     public setExisting(stageId: Id, enableByes: boolean): void {
         this.updateMode = true;
@@ -545,10 +545,14 @@ export class StageCreator {
 
         this.stage.seeding = seeding;
 
-        if (this.stage.seedingIds !== undefined || helpers.isSeedingWithIds(seeding))
-            return this.getSlotsUsingIds(seeding, positions);
+        const slots = this.stage.seedingIds !== undefined || helpers.isSeedingWithIds(seeding)
+            ? await this.getSlotsUsingIds(seeding, positions)
+            : await this.getSlotsUsingNames(seeding, positions);
 
-        return this.getSlotsUsingNames(seeding, positions);
+        if (this.updateMode && !this.enableByesInUpdate)
+            return slots.map(slot => slot === null ? { id: null } : slot);
+
+        return slots;
     }
 
     /**

--- a/src/base/stage/creator.ts
+++ b/src/base/stage/creator.ts
@@ -1,4 +1,4 @@
-import { Group, Id, InputStage, Match, MatchGame, Participant, Round, Seeding, SeedOrdering, Stage } from 'brackets-model';
+import { Group, Id, InputStage, Match, MatchGame, Participant, Round, Seeding, SeedOrdering, Stage, Status } from 'brackets-model';
 import { defaultMinorOrdering, ordering } from '../../ordering';
 import { Duel, Storage, OmitId, ParticipantSlot, StandardBracketResults } from '../../types';
 import { BracketsManager } from '../..';
@@ -420,8 +420,10 @@ export class StageCreator {
 
             if (existing) {
                 // Keep the most advanced status when updating a match.
+                // But we intentionally allow transitions between pending statuses (Locked/Waiting/Ready),
+                // e.g. a TBD match (Waiting) becoming a BYE match (Locked) after confirmSeeding().
                 const existingStatus = helpers.getMatchStatus(existing);
-                if (existingStatus > status)
+                if (existingStatus > status && existingStatus >= Status.Running)
                     status = existingStatus;
             }
         }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1544,16 +1544,21 @@ export function getParentMatchResults(storedParent: Match, scores: Scores): Pick
  * @param enableByes Whether to use BYEs or TBDs for `null` values in an input seeding.
  */
 export function getUpdatedMatchResults<T extends MatchResults>(match: T, existing: T, enableByes: boolean): T {
+    const mergeOpponent = (currentOpponent: ParticipantResult | null, existingOpponent: ParticipantResult | null): ParticipantResult | null => {
+        if (currentOpponent === null)
+            return enableByes ? null : { id: null }; // BYE or TBD.
+
+        if (hasBye(existing))
+            return currentOpponent; // Reset old BYE completion state.
+
+        return { ...existingOpponent, ...currentOpponent };
+    };
+
     return {
         ...existing,
         ...match,
-        ...(enableByes ? {
-            opponent1: match.opponent1 === null ? null : { ...existing.opponent1, ...match.opponent1 },
-            opponent2: match.opponent2 === null ? null : { ...existing.opponent2, ...match.opponent2 },
-        } : {
-            opponent1: match.opponent1 === null ? { id: null } : { ...existing.opponent1, ...match.opponent1 },
-            opponent2: match.opponent2 === null ? { id: null } : { ...existing.opponent2, ...match.opponent2 },
-        }),
+        opponent1: mergeOpponent(match.opponent1, existing.opponent1),
+        opponent2: mergeOpponent(match.opponent2, existing.opponent2),
     };
 }
 

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -792,6 +792,38 @@ describe('Seeding', () => {
         assert.strictEqual((await storage.select('participant')).length, 8); // Participants aren't removed.
     });
 
+    it('should reset the seeding of a stage after confirmation', async () => {
+        await manager.update.seeding(0, [
+            'Team 1', 'Team 2',
+            null, 'Team 4',
+            'Team 5', null,
+            null, null,
+        ]);
+
+        await manager.update.confirmSeeding(0);
+
+        // After confirmation, BYE-won matches are Locked and BYE winners are propagated.
+        assert.strictEqual((await storage.select('match', 1)).opponent1, null); // BYE.
+        assert.strictEqual((await storage.select('match', 1)).status, Status.Locked);
+        assert.strictEqual((await storage.select('match', 4)).opponent2.id, 2); // Team 4 propagated to round 2.
+        assert.strictEqual((await storage.select('match', 4)).status, Status.Waiting);
+
+        await manager.reset.seeding(0);
+
+        // Participants aren't removed.
+        assert.strictEqual((await storage.select('participant')).length, 4);
+
+        // All matches in every round must be fully reset to TBD, Waiting, and without any result.
+        const matches = await storage.select('match');
+        for (const match of matches) {
+            assert.strictEqual(match.opponent1.id, null, `Match ${match.id} opponent1 should be TBD`);
+            assert.strictEqual(match.opponent1.result, undefined, `Match ${match.id} opponent1 should have no result`);
+            assert.strictEqual(match.opponent2.id, null, `Match ${match.id} opponent2 should be TBD`);
+            assert.strictEqual(match.opponent2.result, undefined, `Match ${match.id} opponent2 should have no result`);
+            assert.strictEqual(match.status, Status.Waiting, `Match ${match.id} should be Waiting`);
+        }
+    });
+
     it('should update the seeding in a stage with participants already', async () => {
         await manager.update.seeding(0, [
             'Team 1', 'Team 2',

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -820,7 +820,7 @@ describe('Seeding', () => {
             assert.strictEqual(match.opponent1.result, undefined, `Match ${match.id} opponent1 should have no result`);
             assert.strictEqual(match.opponent2.id, null, `Match ${match.id} opponent2 should be TBD`);
             assert.strictEqual(match.opponent2.result, undefined, `Match ${match.id} opponent2 should have no result`);
-            assert.strictEqual(match.status, Status.Waiting, `Match ${match.id} should be Waiting`);
+            assert.strictEqual(match.status, Status.Locked, `Match ${match.id} should be Locked`);
         }
     });
 

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -980,20 +980,27 @@ describe('Seeding', () => {
         ]);
 
         assert.strictEqual((await storage.select('match', 1)).opponent1.id, null); // First, is a TBD.
+        assert.strictEqual((await storage.select('match', 1)).status, Status.Waiting); // TBD vs. someone is Waiting.
         assert.strictEqual((await storage.select('match', 2)).opponent2.id, null);
+        assert.strictEqual((await storage.select('match', 2)).status, Status.Waiting);
         assert.strictEqual((await storage.select('match', 3)).opponent1.id, null);
         assert.strictEqual((await storage.select('match', 3)).opponent2.id, null);
+        assert.strictEqual((await storage.select('match', 3)).status, Status.Locked); // TBD vs. TBD is Locked.
 
         await manager.update.confirmSeeding(0);
 
         assert.strictEqual((await storage.select('participant')).length, 4);
 
         assert.strictEqual((await storage.select('match', 1)).opponent1, null); // Should become a BYE.
+        assert.strictEqual((await storage.select('match', 1)).status, Status.Locked); // Any match with a BYE is Locked.
         assert.strictEqual((await storage.select('match', 2)).opponent2, null);
+        assert.strictEqual((await storage.select('match', 2)).status, Status.Locked);
         assert.strictEqual((await storage.select('match', 3)).opponent1, null);
         assert.strictEqual((await storage.select('match', 3)).opponent2, null);
+        assert.strictEqual((await storage.select('match', 3)).status, Status.Locked);
 
         assert.strictEqual((await storage.select('match', 5)).opponent2, null); // A BYE should be propagated here.
+        assert.strictEqual((await storage.select('match', 5)).status, Status.Locked);
 
         assert.strictEqual((await storage.select('match', 7)).opponent2, null); // All of these too (in loser bracket).
         assert.strictEqual((await storage.select('match', 8)).opponent1, null);

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -721,10 +721,18 @@ describe('Seeding', () => {
         assert.strictEqual((await storage.select('match', 0)).opponent1.id, 0);
 
         // In this context, a `null` value is not a BYE, but a TDB (to be determined)
-        // because we consider the tournament might have been started.
-        // If it's not and you prefer BYEs, just recreate the tournament.
+        // because we consider the tournament might not have been started yet.
+        // Use confirmSeeding() to convert TBDs to BYEs.
         assert.strictEqual((await storage.select('match', 1)).opponent1.id, null);
+        assert.strictEqual((await storage.select('match', 1)).opponent2.result, undefined);
         assert.strictEqual((await storage.select('match', 3)).opponent2.id, null);
+        assert.strictEqual((await storage.select('match', 3)).opponent1.result, undefined);
+
+        // The participants opposite the TBD slots must not be auto-advanced to round 2.
+        assert.strictEqual((await storage.select('match', 4)).opponent1.id, null);
+        assert.strictEqual((await storage.select('match', 4)).opponent2.id, null);
+        assert.strictEqual((await storage.select('match', 5)).opponent1.id, null);
+        assert.strictEqual((await storage.select('match', 5)).opponent2.id, null);
     });
 
     it('should handle incomplete seeding during seeding update', async () => {


### PR DESCRIPTION
Closes #233

When calling `update.seeding()` with `null` slots, those slots were incorrectly treated as BYEs and their opposite participants were auto-advanced to the next round. This was caused by two bugs:

1. In `StageCreator.createMatch()`, the logic that preserved the existing match status during a seeding update used `existingStatus > status` without a lower bound, causing a `Waiting` status (one participant known) to be overridden by `Locked` (BYE/TBD), which then prevented transitions from `Waiting` back to `Locked`/`Ready` during `confirmSeeding()`.

2. In `StageCreator.getSlots()`, `null` values from the input seeding (TBDs) were not converted to `{ id: null }` in update mode when `enableByes` was false, so they remained as `null` (BYE) slots and triggered bye-win propagation.

A third fix addresses `reset.seeding()` after `confirmSeeding()`: `getUpdatedMatchResults` now avoids merging existing opponent data when the match previously had a BYE, preventing stale `result` fields from being carried over after a reset.