### PR TITLE
fix(creator): handle BYE slots in `manualOrdering`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "node": ">=14"
     },
     "dependencies": {
-        "brackets-model": "^1.6.1",
+        "brackets-model": "^1.6.2",
         "uuid": "^9.0.0"
     },
     "devDependencies": {

--- a/src/base/stage/creator.ts
+++ b/src/base/stage/creator.ts
@@ -1,4 +1,4 @@
-import { Group, Id, InputStage, Match, MatchGame, Participant, Round, Seeding, SeedOrdering, Stage, Status } from 'brackets-model';
+import { Group, Id, InputStage, Match, MatchGame, Participant, Round, Seed, Seeding, SeedOrdering, Stage, Status } from 'brackets-model';
 import { defaultMinorOrdering, ordering } from '../../ordering';
 import { Duel, Storage, OmitId, ParticipantSlot, StandardBracketResults } from '../../types';
 import { BracketsManager } from '../..';
@@ -521,7 +521,7 @@ export class StageCreator {
      *
      * @param positions An optional list of positions (seeds) for a manual ordering.
      */
-    public async getSlots(positions?: number[]): Promise<ParticipantSlot[]> {
+    public async getSlots(positions?: Seed[]): Promise<ParticipantSlot[]> {
         let seeding = this.stage.seedingIds || this.stage.seeding;
         const size = this.stage.settings?.size || seeding?.length || 0;
         helpers.ensureValidSize(this.stage.type, size);
@@ -563,7 +563,7 @@ export class StageCreator {
      * @param seeding The seeding (names).
      * @param positions An optional list of positions (seeds) for a manual ordering.
      */
-    private async getSlotsUsingNames(seeding: Seeding, positions?: number[]): Promise<ParticipantSlot[]> {
+    private async getSlotsUsingNames(seeding: Seeding, positions?: Seed[]): Promise<ParticipantSlot[]> {
         const participants = helpers.extractParticipantsFromSeeding(this.stage.tournamentId, seeding);
 
         if (!await this.registerParticipants(participants))
@@ -582,7 +582,7 @@ export class StageCreator {
      * @param seeding The seeding (IDs).
      * @param positions An optional list of positions (seeds) for a manual ordering.
      */
-    private async getSlotsUsingIds(seeding: Seeding, positions?: number[]): Promise<ParticipantSlot[]> {
+    private async getSlotsUsingIds(seeding: Seeding, positions?: Seed[]): Promise<ParticipantSlot[]> {
         const participants = await this.storage.select('participant', { tournament_id: this.stage.tournamentId });
         if (!participants) throw Error('No available participants.');
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,6 +8,7 @@ import {
     CustomParticipant,
     Result,
     RoundRobinMode,
+    Seed,
     Seeding,
     SeedOrdering,
     Stage,
@@ -1307,7 +1308,7 @@ export function extractParticipantsFromSeeding(tournamentId: Id, seeding: Seedin
  * @param database The participants stored in the database.
  * @param positions An optional list of positions (seeds) for a manual ordering.
  */
-export function mapParticipantsNamesToDatabase(seeding: Seeding, database: Participant[], positions?: number[]): ParticipantSlot[] {
+export function mapParticipantsNamesToDatabase(seeding: Seeding, database: Participant[], positions?: Seed[]): ParticipantSlot[] {
     return mapParticipantsToDatabase('name', seeding, database, positions);
 }
 
@@ -1318,7 +1319,7 @@ export function mapParticipantsNamesToDatabase(seeding: Seeding, database: Parti
  * @param database The participants stored in the database.
  * @param positions An optional list of positions (seeds) for a manual ordering.
  */
-export function mapParticipantsIdsToDatabase(seeding: Seeding, database: Participant[], positions?: number[]): ParticipantSlot[] {
+export function mapParticipantsIdsToDatabase(seeding: Seeding, database: Participant[], positions?: Seed[]): ParticipantSlot[] {
     return mapParticipantsToDatabase('id', seeding, database, positions);
 }
 
@@ -1330,7 +1331,7 @@ export function mapParticipantsIdsToDatabase(seeding: Seeding, database: Partici
  * @param database The participants stored in the database.
  * @param positions An optional list of positions (seeds) for a manual ordering.
  */
-export function mapParticipantsToDatabase(prop: 'id' | 'name', seeding: Seeding, database: Participant[], positions?: number[]): ParticipantSlot[] {
+export function mapParticipantsToDatabase(prop: 'id' | 'name', seeding: Seeding, database: Participant[], positions?: Seed[]): ParticipantSlot[] {
     const slots = seeding.map((slot, i) => {
         if (slot === null) return null; // BYE.
 
@@ -1347,7 +1348,7 @@ export function mapParticipantsToDatabase(prop: 'id' | 'name', seeding: Seeding,
     if (!positions)
         return slots;
 
-    return positions.map(position => slots[position - 1]); // Because `position` is `i + 1`.
+    return positions.map(position => position === null ? null : slots[position - 1]); // Because `position` is `i + 1`.
 }
 
 /**

--- a/test/single-elimination.spec.js
+++ b/test/single-elimination.spec.js
@@ -83,6 +83,27 @@ describe('Create single elimination stage', () => {
         }), 'Manual ordering for an elimination stage must have exactly one group.');
     });
 
+    it('should create a single elimination stage with manual ordering and BYEs', async () => {
+        await manager.create.stage({
+            name: 'Example',
+            tournamentId: 0,
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4', 'Team 5', 'Team 6'],
+            settings: {
+                size: 8,
+                manualOrdering: [[1, 2, 3, null, 4, 5, 6, null]],
+            },
+        });
+
+        const matches = await storage.select('match');
+        assert.strictEqual(matches[1].opponent1.id, 2); // Team 3 advances automatically.
+        assert.strictEqual(matches[1].opponent2, null); // BYE.
+        assert.strictEqual(matches[1].status, 0); // Locked (auto-completed).
+        assert.strictEqual(matches[3].opponent1.id, 5); // Team 6 advances automatically.
+        assert.strictEqual(matches[3].opponent2, null); // BYE.
+        assert.strictEqual(matches[3].status, 0); // Locked (auto-completed).
+    });
+
     it('should throw if manual ordering for single elimination has wrong length', async () => {
         await assert.isRejected(manager.create.stage({
             name: 'Example',


### PR DESCRIPTION
Closes #239

Allow `null` entries in `manualOrdering` to represent BYE positions. Previously, `null - 1` evaluated to `-1`, making the slot `undefined` instead of `null`. Since `hasBye` checks for strict equality with `null`, those matches were not auto-completed and got stuck in `Ready` status instead of `Locked`.

Adds a `Seed` type (`number | null`) in `brackets-model` (v1.6.2) and uses it for the `positions` parameter, with a null-guard in `mapParticipantsToDatabase`.