### PR TITLE
Allow double forfeits and cancelling match games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 .nyc_output
 package-lock.json
 docs
+AGENTS.md

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "node": ">=14"
     },
     "dependencies": {
-        "brackets-model": "^1.6.2",
+        "brackets-model": "^1.6.3",
         "uuid": "^9.0.0"
     },
     "devDependencies": {

--- a/src/base/updater.ts
+++ b/src/base/updater.ts
@@ -89,10 +89,10 @@ export class BaseUpdater extends BaseGetter {
         const games = await this.storage.select('match_game', { parent_id: parentId });
         if (!games) throw Error('No match games.');
 
-        const parentScores = helpers.getChildGamesResults(games);
-        const parent = helpers.getParentMatchResults(storedParent, parentScores);
+        const childResults = helpers.getChildGamesResults(games);
+        const parent = helpers.getParentMatchResults(storedParent, childResults);
 
-        helpers.setParentMatchCompleted(parent, storedParent.child_count, inRoundRobin);
+        helpers.setParentMatchCompleted(parent, childResults, storedParent.child_count, inRoundRobin);
 
         await this.updateMatch(storedParent, parent, true);
     }
@@ -157,6 +157,9 @@ export class BaseUpdater extends BaseGetter {
      * @param force Whether to force update locked matches.
      */
     protected async updateMatch(stored: Match, match: DeepPartial<Match>, force?: boolean): Promise<void> {
+        if (match.status === Status.GameCancelled)
+            throw Error('This status can only be used on match games with cancelMatchGame().');
+
         if (!force && helpers.isMatchUpdateLocked(stored))
             throw Error('The match is locked.');
 
@@ -171,7 +174,7 @@ export class BaseUpdater extends BaseGetter {
         // Don't update related matches if it's a simple score update.
         if (!statusChanged && !resultChanged) return;
 
-        if (!helpers.isRoundRobin(stage))
+        if (!inRoundRobin)
             await this.updateRelatedMatches(stored, statusChanged, resultChanged);
     }
 
@@ -182,6 +185,9 @@ export class BaseUpdater extends BaseGetter {
      * @param game Input of the update.
      */
     protected async updateMatchGame(stored: MatchGame, game: DeepPartial<MatchGame>): Promise<void> {
+        if (game.status === Status.GameCancelled)
+            throw Error('Use cancelMatchGame() to cancel a match game with the right mode.');
+
         if (helpers.isMatchUpdateLocked(stored))
             throw Error('The match game is locked.');
 
@@ -189,6 +195,15 @@ export class BaseUpdater extends BaseGetter {
         if (!stage) throw Error('Stage not found.');
 
         const inRoundRobin = helpers.isRoundRobin(stage);
+
+        const parent = await this.storage.select('match', stored.parent_id);
+        if (!parent) throw Error('Parent not found.');
+
+        if (helpers.isMatchUpdateLocked(parent))
+            throw Error('The parent match of this match game is locked.');
+
+        if (!inRoundRobin && game.opponent1?.forfeit === true && game.opponent2?.forfeit === true)
+            throw Error('Use cancelMatchGame() to double-forfeit a match game.');
 
         helpers.setMatchResults(stored, game, inRoundRobin);
 
@@ -288,11 +303,13 @@ export class BaseUpdater extends BaseGetter {
             return;
         }
 
-        const winnerSide = helpers.getMatchResult(match);
+        const outcome = helpers.getMatchOutcome(match);
         const actualRoundNumber = (stage.settings.skipFirstRound && matchLocation === 'winner_bracket') ? roundNumber + 1 : roundNumber;
 
-        if (winnerSide)
-            await this.applyToNextMatches(helpers.setNextOpponent, match, matchLocation, actualRoundNumber, roundCount, nextMatches, winnerSide);
+        if (outcome === 'double_forfeit')
+            await this.applyToNextMatches(helpers.setNextOpponentToBye, match, matchLocation, actualRoundNumber, roundCount, nextMatches);
+        else if (outcome)
+            await this.applyToNextMatches(helpers.setNextOpponent, match, matchLocation, actualRoundNumber, roundCount, nextMatches, outcome);
         else
             await this.applyToNextMatches(helpers.resetNextOpponent, match, matchLocation, actualRoundNumber, roundCount, nextMatches);
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,7 +20,7 @@ import {
     RankingFormula,
 } from 'brackets-model';
 
-import { Database, DeepPartial, Duel, FinalStandingsItem, IdMapping, Nullable, OmitId, ParitySplit, ParticipantSlot, Scores, Side } from './types';
+import { ChildGameResults, Database, DeepPartial, Duel, FinalStandingsItem, IdMapping, Nullable, OmitId, ParitySplit, ParticipantSlot, Scores, Side } from './types';
 import { ordering } from './ordering';
 
 /**
@@ -467,6 +467,8 @@ export function getLoser(match: MatchResults): ParticipantSlot {
     return match[getOtherSide(winnerSide)];
 }
 
+export type MatchOutcome = Side | 'double_forfeit' | null;
+
 /**
  * Returns the pre-computed winner for a match because of BYEs.
  *
@@ -517,8 +519,21 @@ export function byeLoser(opponents: Duel, index: number): ParticipantSlot {
  * @param match A match's results.
  */
 export function getMatchResult(match: MatchResults): Side | null {
+    const outcome = getMatchOutcome(match);
+    return outcome === 'double_forfeit' ? null : outcome;
+}
+
+/**
+ * Returns the outcome of a match, including the case of a double forfeit.
+ *
+ * @param match A match's results.
+ */
+export function getMatchOutcome(match: MatchResults): MatchOutcome {
     if (!isMatchCompleted(match))
         return null;
+
+    if (isDoubleForfeitCompleted(match))
+        return 'double_forfeit';
 
     if (isMatchDrawCompleted(match))
         return null;
@@ -654,6 +669,15 @@ export function isMatchForfeitCompleted(match: DeepPartial<MatchResults>): boole
 }
 
 /**
+ * Checks if both opponents forfeited.
+ *
+ * @param match Partial match results.
+ */
+export function isDoubleForfeitCompleted(match: DeepPartial<MatchResults>): boolean {
+    return match.opponent1?.forfeit === true && match.opponent2?.forfeit === true;
+}
+
+/**
  * Checks if a match is completed because of a either a draw or a win.
  * 
  * @param match Partial match results.
@@ -700,7 +724,8 @@ export function isMatchByeCompleted(match: DeepPartial<MatchResults>): boolean {
  * @param match The match to check.
  */
 export function isMatchUpdateLocked(match: MatchResults): boolean {
-    return match.status === Status.Locked || match.status === Status.Waiting || match.status === Status.Archived || isMatchByeCompleted(match);
+    return match.status === Status.Locked || match.status === Status.Waiting || match.status === Status.Archived
+        || match.status === Status.GameCancelled || isMatchByeCompleted(match);
 }
 
 /**
@@ -790,12 +815,12 @@ export function setMatchResults(stored: MatchResults, match: DeepPartial<MatchRe
 
     if (completed && currentlyCompleted) {
         // Ensure everything is good.
-        setCompleted(stored, match, inRoundRobin);
+        setCompleted(stored, match);
         return { statusChanged: false, resultChanged: true };
     }
 
     if (completed && !currentlyCompleted) {
-        setCompleted(stored, match, inRoundRobin);
+        setCompleted(stored, match);
         return { statusChanged: true, resultChanged: true };
     }
 
@@ -1057,6 +1082,17 @@ export function setNextOpponent(nextMatch: Match, nextSide: Side, match?: Match,
 }
 
 /**
+ * Sets a BYE in the next match.
+ *
+ * @param nextMatch A match which follows the current one.
+ * @param nextSide The side the BYE will be on in the next match.
+ */
+export function setNextOpponentToBye(nextMatch: Match, nextSide: Side): void {
+    nextMatch[nextSide] = null;
+    nextMatch.status = getMatchStatus(nextMatch);
+}
+
+/**
  * Resets an opponent in the match following the current one.
  *
  * @param nextMatch A match which follows the current one.
@@ -1177,14 +1213,13 @@ export function getInferredResult(opponent1: ParticipantSlot, opponent2: Partici
  *
  * @param stored A reference to what will be updated in the storage.
  * @param match Input of the update.
- * @param inRoundRobin Indicates whether the match is in a round-robin stage.
  */
-export function setCompleted(stored: MatchResults, match: DeepPartial<MatchResults>, inRoundRobin: boolean): void {
+export function setCompleted(stored: MatchResults, match: DeepPartial<MatchResults>): void {
     stored.status = Status.Completed;
 
-    setResults(stored, match, 'win', 'loss', inRoundRobin);
-    setResults(stored, match, 'loss', 'win', inRoundRobin);
-    setResults(stored, match, 'draw', 'draw', inRoundRobin);
+    setResults(stored, match, 'win', 'loss');
+    setResults(stored, match, 'loss', 'win');
+    setResults(stored, match, 'draw', 'draw');
 
     const { opponent1, opponent2 } = getInferredResult(stored.opponent1, stored.opponent2);
 
@@ -1203,18 +1238,14 @@ export function setCompleted(stored: MatchResults, match: DeepPartial<MatchResul
  * @param match Input of the update.
  * @param check A result to check in each opponent.
  * @param change A result to set in each other opponent if `check` is correct.
- * @param inRoundRobin Indicates whether the match is in a round-robin stage.
  */
-export function setResults(stored: MatchResults, match: DeepPartial<MatchResults>, check: Result, change: Result, inRoundRobin: boolean): void {
+export function setResults(stored: MatchResults, match: DeepPartial<MatchResults>, check: Result, change: Result): void {
     if (match.opponent1 && match.opponent2) {
         if (match.opponent1.result === 'win' && match.opponent2.result === 'win')
             throw Error('There are two winners.');
 
         if (match.opponent1.result === 'loss' && match.opponent2.result === 'loss')
             throw Error('There are two losers.');
-
-        if (!inRoundRobin && match.opponent1.forfeit === true && match.opponent2.forfeit === true)
-            throw Error('There are two forfeits.');
     }
 
     if (match.opponent1?.result === check) {
@@ -1241,27 +1272,49 @@ export function setResults(stored: MatchResults, match: DeepPartial<MatchResults
  * @param match Input of the update.
  */
 export function setForfeits(stored: MatchResults, match: DeepPartial<MatchResults>): void {
-    if (match.opponent1?.forfeit === true && match.opponent2?.forfeit === true) {
-        if (stored.opponent1) stored.opponent1.forfeit = true;
-        if (stored.opponent2) stored.opponent2.forfeit = true;
+    const opponent1Forfeits = (match.opponent1?.forfeit === true || stored.opponent1?.forfeit === true);
+    const opponent2Forfeits = (match.opponent2?.forfeit === true || stored.opponent2?.forfeit === true);
+    const doubleForfeit = opponent1Forfeits && opponent2Forfeits;
+
+    const forfeit = (side: Side): void => {
+        const opponent = stored[side];
+        if (!opponent)
+            return;
+
+        // Keep the score but reset the result.
+        delete opponent.result;
+        opponent.forfeit = true;
+    };
+
+    if (doubleForfeit) {
+        forfeit('opponent1');
+        forfeit('opponent2');
 
         // Don't set any result (win/draw/loss) with a double forfeit 
-        // so that it doesn't count any point in the ranking.
+        // so that it doesn't count any point in round-robin ranking.
         return;
     }
 
-    if (match.opponent1?.forfeit === true) {
-        if (stored.opponent1) stored.opponent1.forfeit = true;
+    const winDueToForfeit = (side: Side): void => {
+        const opponent = stored[side];
+        if (!opponent) {
+            stored[side] = { id: null, result: 'win' };
+            return;
+        }
 
-        if (stored.opponent2) stored.opponent2.result = 'win';
-        else stored.opponent2 = { id: null, result: 'win' };
+        // Since we aren't in double-forfeit case, reset the forfeit value.
+        delete opponent.forfeit;
+        opponent.result = 'win';
+    };
+
+    if (match.opponent1?.forfeit === true) {
+        forfeit('opponent1');
+        winDueToForfeit('opponent2');
     }
 
     if (match.opponent2?.forfeit === true) {
-        if (stored.opponent2) stored.opponent2.forfeit = true;
-
-        if (stored.opponent1) stored.opponent1.result = 'win';
-        else stored.opponent1 = { id: null, result: 'win' };
+        forfeit('opponent2');
+        winDueToForfeit('opponent1');
     }
 }
 
@@ -1488,29 +1541,64 @@ export function transitionToMinor(previousDuels: Duel[], losers: ParticipantSlot
  * Sets the parent match to a completed status if all its child games are completed.
  *
  * @param parent The partial parent match to update.
+ * @param childResults The cumulated results of this parent match's child games.
  * @param childCount Child count of this parent match.
  * @param inRoundRobin Indicates whether the parent match is in a round-robin stage.
  */
-export function setParentMatchCompleted(parent: Pick<MatchResults, 'opponent1' | 'opponent2'>, childCount: number, inRoundRobin: boolean): void {
+export function setParentMatchCompleted(parent: Pick<MatchResults, 'opponent1' | 'opponent2'>, childResults: ChildGameResults, childCount: number, inRoundRobin: boolean): void {
     if (parent.opponent1?.score === undefined || parent.opponent2?.score === undefined)
         throw Error('Either opponent1, opponent2 or their scores are falsy.');
 
     const minToWin = minScoreToWinBestOfX(childCount);
+    const minToWinWithCancellations = Math.max(1, minToWin - childResults.spent);
 
-    if (parent.opponent1.score >= minToWin) {
+    // A cancelled child game can explicitly double-forfeit the parent, or spent games can consume
+    // enough of the series that no opponent can still reach the original win threshold.
+    if (childResults.doubleForfeit || childResults.spent >= minToWin) {
+        parent.opponent1.forfeit = true;
+        parent.opponent2.forfeit = true;
+        return;
+    }
+
+    // Spent games shorten the series, so both opponents can reach the adjusted win threshold at once.
+    if (parent.opponent1.score >= minToWinWithCancellations && parent.opponent2.score >= minToWinWithCancellations) {
+        if (inRoundRobin) {
+            parent.opponent1.result = 'draw';
+            parent.opponent2.result = 'draw';
+            return;
+        }
+
+        // Unlike the earlier double-forfeit cases, this tie emerges only after every available child game
+        // has been resolved and at least one of them was spent by cancellation.
+        if (childResults.spent > 0) {
+            parent.opponent1.forfeit = true;
+            parent.opponent2.forfeit = true;
+            return;
+        }
+
+        throw Error('Match games result in a tie for the parent match.');
+    }
+
+    if (parent.opponent1.score >= minToWinWithCancellations) {
         parent.opponent1.result = 'win';
         return;
     }
 
-    if (parent.opponent2.score >= minToWin) {
+    if (parent.opponent2.score >= minToWinWithCancellations) {
         parent.opponent2.result = 'win';
         return;
     }
 
-    if (parent.opponent1.score === parent.opponent2.score && parent.opponent1.score + parent.opponent2.score > childCount - 1) {
+    if (parent.opponent1.score === parent.opponent2.score && parent.opponent1.score + parent.opponent2.score + childResults.spent > childCount - 1) {
         if (inRoundRobin) {
             parent.opponent1.result = 'draw';
             parent.opponent2.result = 'draw';
+            return;
+        }
+
+        if (childResults.spent > 0) {
+            parent.opponent1.forfeit = true;
+            parent.opponent2.forfeit = true;
             return;
         }
 
@@ -1568,13 +1656,24 @@ export function getUpdatedMatchResults<T extends MatchResults>(match: T, existin
  *
  * @param games The child games to process.
  */
-export function getChildGamesResults(games: MatchGame[]): Scores {
-    const scores = {
+export function getChildGamesResults(games: MatchGame[]): ChildGameResults {
+    const scores: ChildGameResults = {
         opponent1: 0,
         opponent2: 0,
+        spent: 0,
+        doubleForfeit: false,
     };
 
     for (const game of games) {
+        if (game.status === Status.GameCancelled) {
+            if (isDoubleForfeitCompleted(game))
+                scores.doubleForfeit = true;
+            else
+                scores.spent++;
+
+            continue;
+        }
+
         const result = getMatchResult(game);
         if (result === 'opponent1') scores.opponent1++;
         else if (result === 'opponent2') scores.opponent2++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ export {
     Nullable,
     DeepPartial,
     ChildCountLevel,
+    ChildGameResults,
+    MatchGameCancellationOptions,
 } from './types';
 
 export * as helpers from './helpers';

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,9 +41,37 @@ export type Side = 'opponent1' | 'opponent2';
 export type Scores = { opponent1: number, opponent2: number };
 
 /**
+ * The cumulated results of a match's child games.
+ */
+export interface ChildGameResults extends Scores {
+    /**
+     * The count of match games cancelled as spent games.
+     */
+    spent: number,
+
+    /**
+     * Whether a match game cancelled the whole parent match as a double forfeit.
+     */
+    doubleForfeit: boolean,
+}
+
+/**
  * The possible levels of data to which we can update the child games count.
  */
 export type ChildCountLevel = 'stage' | 'group' | 'round' | 'match';
+
+/**
+ * Options for cancelling a match game.
+ */
+export interface MatchGameCancellationOptions {
+    /**
+     * How cancelling a match game should affect its parent match.
+     *
+     * - `spent_game`: Consumes one Best-of-X game without awarding it to either opponent.
+     * - `double_forfeit`: Disqualifies both opponents from the parent match.
+     */
+    mode: 'spent_game' | 'double_forfeit',
+}
 
 /**
  * Positional information about a round.

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,7 +1,7 @@
 import { Id, IdSeeding, Match, MatchGame, Round, Seeding, SeedOrdering, Status } from 'brackets-model';
 import { ordering } from './ordering';
 import { BaseUpdater } from './base/updater';
-import { ChildCountLevel, DeepPartial } from './types';
+import { ChildCountLevel, DeepPartial, MatchGameCancellationOptions } from './types';
 import * as helpers from './helpers';
 
 export class Update extends BaseUpdater {
@@ -34,6 +34,60 @@ export class Update extends BaseUpdater {
         const stored = await this.findMatchGame(game);
 
         await this.updateMatchGame(stored, game);
+    }
+
+    /**
+     * Cancels a match game.
+     *
+     * @param gameId ID of the match game.
+     * @param options Options for cancelling a match game.
+     */
+    public async cancelMatchGame(gameId: Id, options: MatchGameCancellationOptions): Promise<void> {
+        const stored = await this.storage.select('match_game', gameId);
+        if (!stored) throw Error('Match game not found.');
+
+        if (!options || options.mode !== 'spent_game' && options.mode !== 'double_forfeit')
+            throw Error('Invalid match game cancellation mode.');
+
+        if (helpers.isMatchUpdateLocked(stored))
+            throw Error('The match game is locked.');
+
+        const parent = await this.storage.select('match', stored.parent_id);
+        if (!parent) throw Error('Parent not found.');
+        if (parent.status === Status.Archived || helpers.isDoubleForfeitCompleted(parent))
+            throw Error('The match game is locked.');
+
+        stored.status = Status.GameCancelled;
+
+        if (stored.opponent1) {
+            delete stored.opponent1.score;
+            delete stored.opponent1.result;
+            if (options.mode === 'double_forfeit') stored.opponent1.forfeit = true;
+            else delete stored.opponent1.forfeit;
+        }
+
+        if (stored.opponent2) {
+            delete stored.opponent2.score;
+            delete stored.opponent2.result;
+            if (options.mode === 'double_forfeit') stored.opponent2.forfeit = true;
+            else delete stored.opponent2.forfeit;
+        }
+
+        if (!await this.storage.update('match_game', stored.id, stored))
+            throw Error('Could not update the match game.');
+
+        if (options.mode === 'double_forfeit') {
+            await this.updateMatch(parent, {
+                opponent1: { forfeit: true },
+                opponent2: { forfeit: true },
+            }, true);
+            return;
+        }
+
+        const stage = await this.storage.select('stage', stored.stage_id);
+        if (!stage) throw Error('Stage not found.');
+
+        await this.updateParentMatch(stored.parent_id, helpers.isRoundRobin(stage));
     }
 
     /**

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -276,12 +276,21 @@ describe('Update matches', () => {
         }), 'There are two losers.');
     });
 
-    it('should throw if two forfeits', async () => {
-        await assert.isRejected(manager.update.match({
+    it('should allow double forfeits', async () => {
+        await manager.update.match({
             id: 3,
             opponent1: { forfeit: true },
             opponent2: { forfeit: true },
-        }), 'There are two forfeits.');
+        });
+
+        const after = await storage.select('match', 3);
+        assert.isAtLeast(after.status, Status.Completed);
+        assert.strictEqual(after.opponent1.forfeit, true);
+        assert.strictEqual(after.opponent2.forfeit, true);
+        assert.notExists(after.opponent1.result);
+        assert.notExists(after.opponent2.result);
+
+        await manager.reset.matchResults(3);
     });
 
     it('should throw if draws in elimination stage', async () => {
@@ -304,7 +313,7 @@ describe('Update matches', () => {
         }), 'Having a draw is forbidden in an elimination tournament.');
     });
 
-    it('should throw if one forfeit then the other without resetting the match between', async () => {
+    it('should allow double forfeit when they are set one after the other', async () => {
         await manager.update.match({
             id: 4,
             opponent1: { forfeit: true },
@@ -314,10 +323,256 @@ describe('Update matches', () => {
         assert.strictEqual(after.opponent1.forfeit, true);
         assert.notExists(after.opponent2.forfeit);
 
-        manager.update.match({
+        await manager.update.match({
             id: 4,
             opponent2: { forfeit: true },
         });
+
+        after = await storage.select('match', 4);
+        assert.strictEqual(after.opponent1.forfeit, true);
+        assert.strictEqual(after.opponent2.forfeit, true);
+
+        await manager.reset.matchResults(4);
+    });
+
+    it('forfeit should reset result', async () => {
+        await manager.update.match({
+            id: 4,
+            opponent1: { result: 'win' },
+        });
+
+        let after = await storage.select('match', 4);
+        assert.strictEqual(after.opponent1.result, 'win');
+        assert.strictEqual(after.opponent2.result, 'loss');
+
+        await manager.update.match({
+            id: 4,
+            opponent1: { forfeit: true },
+        });
+
+        after = await storage.select('match', 4);
+        assert.strictEqual(after.opponent1.forfeit, true);
+        assert.strictEqual(after.opponent1.result, undefined);
+        assert.strictEqual(after.opponent2.forfeit, undefined);
+        assert.strictEqual(after.opponent2.result, 'win');
+
+        await manager.update.match({
+            id: 4,
+            opponent2: { forfeit: true },
+        });
+
+        after = await storage.select('match', 4);
+        assert.strictEqual(after.opponent1.forfeit, true);
+        assert.strictEqual(after.opponent1.result, undefined);
+        assert.strictEqual(after.opponent2.forfeit, true);
+        assert.strictEqual(after.opponent2.result, undefined);
+
+        await manager.reset.matchResults(4);
+    });
+});
+
+describe('Match game cancellation', () => {
+
+    beforeEach(() => {
+        storage.reset();
+    });
+
+    it('should reject GameCancelled status on parent matches and direct match game updates', async () => {
+        await manager.create.stage({
+            tournamentId: 0,
+            name: 'Example',
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2'],
+            settings: { matchesChildCount: 1 },
+        });
+
+        await assert.isRejected(manager.update.match({ id: 0, status: Status.GameCancelled }), 'This status can only be used on match games with cancelMatchGame().');
+        await assert.isRejected(manager.update.matchGame({ id: 0, status: Status.GameCancelled }), 'Use cancelMatchGame() to cancel a match game with the right mode.');
+    });
+
+    it('should turn a spent BO1 cancellation into a parent double forfeit', async () => {
+        await manager.create.stage({
+            tournamentId: 0,
+            name: 'Example',
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+            settings: { matchesChildCount: 1 },
+        });
+
+        await manager.update.cancelMatchGame(0, { mode: 'spent_game' });
+
+        const game = await storage.select('match_game', 0);
+        assert.strictEqual(game.status, Status.GameCancelled);
+        assert.notExists(game.opponent1.forfeit);
+        assert.notExists(game.opponent2.forfeit);
+
+        const match = await storage.select('match', 0);
+        assert.strictEqual(match.status, Status.Completed);
+        assert.strictEqual(match.opponent1.forfeit, true);
+        assert.strictEqual(match.opponent2.forfeit, true);
+        assert.notExists(match.opponent1.result);
+        assert.notExists(match.opponent2.result);
+
+        const final = await storage.select('match', 2);
+        assert.strictEqual(final.opponent1, null);
+    });
+
+    it('should make a BO3 effectively BO1 after a spent cancellation', async () => {
+        await manager.create.stage({
+            tournamentId: 0,
+            name: 'Example',
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+            settings: { matchesChildCount: 3 },
+        });
+
+        await manager.update.cancelMatchGame(0, { mode: 'spent_game' });
+        assert.strictEqual((await storage.select('match', 0)).status, Status.Running);
+
+        await manager.update.matchGame({ id: 1, opponent2: { result: 'win' } });
+
+        const match = await storage.select('match', 0);
+        assert.strictEqual(match.status, Status.Completed);
+        assert.strictEqual(match.opponent1.score, 0);
+        assert.strictEqual(match.opponent2.score, 1);
+        assert.strictEqual(match.opponent2.result, 'win');
+
+        const games = await storage.select('match_game', { parent_id: 0 });
+        assert.strictEqual(games[0].status, Status.GameCancelled);
+        assert.strictEqual(games[1].status, Status.Completed);
+        assert.strictEqual(games[2].status, Status.Ready);
+    });
+
+    it('should resolve BO3 score 1-0 plus a spent cancellation for the leading opponent', async () => {
+        await manager.create.stage({
+            tournamentId: 0,
+            name: 'Example',
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+            settings: { matchesChildCount: 3 },
+        });
+
+        await manager.update.matchGame({ id: 0, opponent1: { result: 'win' } });
+        await manager.update.cancelMatchGame(1, { mode: 'spent_game' });
+
+        const match = await storage.select('match', 0);
+        assert.strictEqual(match.status, Status.Completed);
+        assert.strictEqual(match.opponent1.score, 1);
+        assert.strictEqual(match.opponent2.score, 0);
+        assert.strictEqual(match.opponent1.result, 'win');
+
+        assert.strictEqual((await storage.select('match_game', 2)).status, Status.Ready);
+    });
+
+    it('should double-forfeit BO3 score 1-1 plus a spent final-game cancellation', async () => {
+        await manager.create.stage({
+            tournamentId: 0,
+            name: 'Example',
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+            settings: { matchesChildCount: 3 },
+        });
+
+        await manager.update.matchGame({ id: 0, opponent1: { result: 'win' } });
+        await manager.update.matchGame({ id: 1, opponent2: { result: 'win' } });
+        await manager.update.cancelMatchGame(2, { mode: 'spent_game' });
+
+        const match = await storage.select('match', 0);
+        assert.strictEqual(match.status, Status.Completed);
+        assert.strictEqual(match.opponent1.score, 1);
+        assert.strictEqual(match.opponent2.score, 1);
+        assert.strictEqual(match.opponent1.forfeit, true);
+        assert.strictEqual(match.opponent2.forfeit, true);
+        assert.notExists(match.opponent1.result);
+        assert.notExists(match.opponent2.result);
+    });
+
+    it('should double-forfeit the parent from explicit child cancellation mode', async () => {
+        await manager.create.stage({
+            tournamentId: 0,
+            name: 'Example',
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+            settings: { matchesChildCount: 3 },
+        });
+
+        await manager.update.matchGame({ id: 0, opponent1: { result: 'win' } });
+        await manager.update.cancelMatchGame(1, { mode: 'double_forfeit' });
+
+        const game = await storage.select('match_game', 1);
+        assert.strictEqual(game.status, Status.GameCancelled);
+        assert.strictEqual(game.opponent1.forfeit, true);
+        assert.strictEqual(game.opponent2.forfeit, true);
+
+        const match = await storage.select('match', 0);
+        assert.strictEqual(match.status, Status.Completed);
+        assert.strictEqual(match.opponent1.forfeit, true);
+        assert.strictEqual(match.opponent2.forfeit, true);
+        assert.notExists(match.opponent1.result);
+        assert.notExists(match.opponent2.result);
+    });
+
+    it('should leave unplayed games available when a child game result is reset', async () => {
+        await manager.create.stage({
+            tournamentId: 0,
+            name: 'Example',
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+            settings: { matchesChildCount: 3 },
+        });
+
+        await manager.update.matchGame({ id: 0, opponent1: { result: 'win' } });
+        await manager.update.matchGame({ id: 1, opponent1: { result: 'win' } });
+        assert.strictEqual((await storage.select('match_game', 2)).status, Status.Ready);
+
+        await manager.reset.matchGameResults(1);
+
+        assert.strictEqual((await storage.select('match', 0)).status, Status.Running);
+        assert.strictEqual((await storage.select('match_game', 2)).status, Status.Ready);
+    });
+});
+
+describe('Double forfeit propagation', () => {
+
+    beforeEach(() => {
+        storage.reset();
+    });
+
+    it('should create BYEs in final and consolation final for single elimination', async () => {
+        await manager.create.stage({
+            tournamentId: 0,
+            name: 'Example',
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+            settings: { consolationFinal: true },
+        });
+
+        await manager.update.match({
+            id: 0,
+            opponent1: { forfeit: true },
+            opponent2: { forfeit: true },
+        });
+
+        assert.strictEqual((await storage.select('match', 2)).opponent1, null);
+        assert.strictEqual((await storage.select('match', 3)).opponent1, null);
+    });
+
+    it('should create BYEs in winner and loser brackets for double elimination', async () => {
+        await manager.create.stage({
+            tournamentId: 0,
+            name: 'Example',
+            type: 'double_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+        });
+
+        await manager.update.match({
+            id: 0,
+            opponent1: { forfeit: true },
+            opponent2: { forfeit: true },
+        });
+
+        assert.strictEqual((await storage.select('match', 2)).opponent1, null);
+        assert.strictEqual((await storage.select('match', 3)).opponent1, null);
     });
 });
 
@@ -571,7 +826,6 @@ describe('Update match games', () => {
 
         await manager.update.matchGame({ id: 0, opponent1: { result: 'win' } });
         await manager.update.matchGame({ id: 1, opponent1: { result: 'win' } });
-        await manager.update.matchGame({ id: 2, opponent2: { result: 'win' } });
 
         assert.strictEqual(
             (await storage.select('match', 2)).opponent1.id, // Should be determined automatically.


### PR DESCRIPTION
### What and why?

Closes #214 

This PR adds first-class handling for double forfeits and match-game cancellations.

Organizers sometimes need to mark a match or a Best-of-X child game as administratively forfeited or cancelled without inventing a winner or treating it as a draw. This makes those cases explicit and keeps ranking/bracket propagation consistent.

### How?

- Allows double forfeits on matches. Both opponents are marked as forfeited, no `result` is set, and existing scores are kept when a forfeit is applied after scores/results already exist.
- Adds `manager.update.cancelMatchGame(gameId, { mode })` for cancelling match games with an explicit mode:
  - `spent_game`: consumes one Best-of-X game without awarding it to either opponent.
  - `double_forfeit`: cancels the game and double-forfeits the parent match.
- Rejects setting `Status.GameCancelled` through normal `match()` or `matchGame()` updates, so cancellations go through the dedicated API.
- Propagates double-forfeit outcomes as BYEs in elimination brackets, since no opponent advances.
- Keeps remaining Best-of-X child games available after the parent match is decided, so organizers can still record them if needed.

### Tests

- Added coverage for direct and sequential double forfeits.
- Added match-game cancellation scenarios for BO1/BO3, spent games, explicit double-forfeit cancellation, and parent propagation.
- Added coverage for preserving scores while resetting results on forfeits.
