### PR TITLE
Fix seeding order not preserved due to TBDs

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1429,25 +1429,25 @@ export function convertSlotsToSeeding(slots: ParticipantSlot[]): Seeding {
 }
 
 /**
- * Sorts the seeding with the BYEs in the correct position.
+ * Sorts the seeding with empty seed slots (TBD or BYE) in the correct position.
  *
  * @param slots A list of slots to sort.
  */
 export function sortSeeding(slots: ParticipantSlot[]): ParticipantSlot[] {
-    const withoutByes = slots.filter(v => v !== null);
+    const positionedSlots = slots.filter(v => v !== null && (v.id !== null || v.position !== undefined));
 
     // a and b are not null because of the filter.
     // The slots are from seeding slots, thus they have a position.
-    withoutByes.sort((a, b) => a!.position! - b!.position!);
+    positionedSlots.sort((a, b) => a!.position! - b!.position!);
 
-    if (withoutByes.length === slots.length)
-        return withoutByes;
+    if (positionedSlots.length === slots.length)
+        return positionedSlots;
 
     // Same for v and position.
-    const placed = Object.fromEntries(withoutByes.map(v => [v!.position! - 1, v]));
-    const sortedWithByes = Array.from({ length: slots.length }, (_, i) => placed[i] || null);
+    const placed = Object.fromEntries(positionedSlots.map(v => [v!.position! - 1, v]));
+    const sorted = Array.from({ length: slots.length }, (_, i) => placed[i] || null);
 
-    return sortedWithByes;
+    return sorted;
 }
 
 /**

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -1320,6 +1320,30 @@ describe('Seeding', () => {
     });
 });
 
+describe('Seeding (custom setup)', () => {
+
+    beforeEach(() => {
+        storage.reset();
+    });
+
+    it('seeding order is preserved', async () => {
+        const seeding = ['Team 1', 'Team 2', 'Team 3', null];
+        const expected = [{ id: 0, position: 1 }, { id: 1, position: 2 }, { id: 2, position: 3 }, null];
+        await manager.create.stage({
+            name: 'Example',
+            tournamentId: 0,
+            type: 'double_elimination',
+            seeding,
+        });
+
+        assert.deepEqual(await manager.get.seeding(0), expected);
+        await manager.update.seeding(0, seeding);
+        assert.deepEqual(await manager.get.seeding(0), expected);
+        await manager.update.confirmSeeding(0);
+        assert.deepEqual(await manager.get.seeding(0), expected);
+    });
+});
+
 describe('Match games status', () => {
 
     beforeEach(() => {


### PR DESCRIPTION
Related to https://github.com/Drarig29/brackets-manager.js/issues/184

Fix `update.seeding()` followed by `update.confirmSeeding()` with unnatural seeding order.