### PR TITLE
Fix round-robin pool ordering and balance uneven groups

### DIFF
--- a/src/base/stage/creator.ts
+++ b/src/base/stage/creator.ts
@@ -663,8 +663,14 @@ export class StageCreator {
 
             const positions = this.stage.settings?.manualOrdering.flat();
             const slots = await this.getSlots(positions);
+            let cursor = 0;
 
-            return helpers.makeGroups(slots, this.stage.settings.groupCount);
+            return this.stage.settings.manualOrdering.map(group => {
+                const slotsGroup = slots.slice(cursor, cursor + group.length);
+                cursor += group.length;
+
+                return slotsGroup;
+            });
         }
 
         if (Array.isArray(this.stage.settings.seedOrdering) && this.stage.settings.seedOrdering.length !== 1)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -83,8 +83,10 @@ export function makeRoundRobinMatches<T>(participants: T[], mode: RoundRobinMode
     if (mode === 'simple')
         return distribution;
 
-    // Reverse rounds and their content.
-    const symmetry = distribution.map(round => [...round].reverse()).reverse();
+    // Mirror the same rounds with inverted home/away sides.
+    const symmetry = distribution.map(round =>
+        round.map(([opponent1, opponent2]) => [opponent2, opponent1] as [T, T]),
+    );
 
     return [...distribution, ...symmetry];
 }
@@ -173,14 +175,16 @@ export function assertRoundRobin(input: number[], output: [number, number][][]):
  * @param groupCount The group count.
  */
 export function makeGroups<T>(elements: T[], groupCount: number): T[][] {
-    const groupSize = Math.ceil(elements.length / groupCount);
     const result: T[][] = [];
+    const minGroupSize = Math.floor(elements.length / groupCount);
+    const extraGroups = elements.length % groupCount;
+    let cursor = 0;
 
-    for (let i = 0; i < elements.length; i++) {
-        if (i % groupSize === 0)
-            result.push([]);
+    for (let i = 0; i < groupCount; i++) {
+        const groupSize = minGroupSize + (i < extraGroups ? 1 : 0);
+        result.push(elements.slice(cursor, cursor + groupSize));
 
-        result[result.length - 1].push(elements[i]);
+        cursor += groupSize;
     }
 
     return result;

--- a/src/ordering.ts
+++ b/src/ordering.ts
@@ -48,16 +48,22 @@ export const ordering: OrderingMap = {
     },
     'groups.seed_optimized': <T>(array: T[], groupCount: number) => {
         const groups = Array.from({ length: groupCount }, (_): T[] => []);
+        const minGroupSize = Math.floor(array.length / groupCount);
+        const extraGroups = array.length % groupCount;
+        const groupSizes = groups.map((_, group) => minGroupSize + (group < extraGroups ? 1 : 0));
+        let index = 0;
 
-        for (let run = 0; run < array.length / groupCount; run++) {
-            if (run % 2 === 0) {
-                for (let group = 0; group < groupCount; group++)
-                    groups[group].push(array[run * groupCount + group]);
+        for (let run = 0; index < array.length; run++) {
+            const groupOrder = run % 2 === 0
+                ? groups.map((_, group) => group)
+                : groups.map((_, group) => groupCount - group - 1);
 
-            } else {
-                for (let group = 0; group < groupCount; group++)
-                    groups[groupCount - group - 1].push(array[run * groupCount + group]);
+            for (const group of groupOrder) {
+                if (index >= array.length) break;
+                if (groups[group].length >= groupSizes[group]) continue;
 
+                groups[group].push(array[index]);
+                index++;
             }
         }
 
@@ -120,7 +126,8 @@ export const ordering: OrderingMap = {
         for (let i = 0; i < pairCount; i++) {
             const base = baseGroupForPair(i);
             const aIndex = positions[2 * i] - 1; // convert to 0-based
-            groups[base].push(array[aIndex]);
+            if (aIndex < array.length)
+                groups[base].push(array[aIndex]);
         }
 
         // Then, distribute the second element of each pair to the opposite
@@ -128,7 +135,8 @@ export const ordering: OrderingMap = {
         for (let i = 0; i < pairCount; i++) {
             const base = baseGroupForPair(i);
             const bIndex = positions[2 * i + 1] - 1; // convert to 0-based
-            groups[(base + halfGroupCount) % groupCount].push(array[bIndex]);
+            if (bIndex < array.length)
+                groups[(base + halfGroupCount) % groupCount].push(array[bIndex]);
         }
 
         // Sort each group by original seed order so the strongest seed of the

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -10,6 +10,12 @@ describe('Helpers', () => {
             assert.deepStrictEqual(makeGroups([1, 2, 3, 4, 5], 2), [[1, 2, 3], [4, 5]]);
             assert.deepStrictEqual(makeGroups([1, 2, 3, 4, 5, 6, 7, 8], 2), [[1, 2, 3, 4], [5, 6, 7, 8]]);
             assert.deepStrictEqual(makeGroups([1, 2, 3, 4, 5, 6, 7, 8], 3), [[1, 2, 3], [4, 5, 6], [7, 8]]);
+            assert.deepStrictEqual(makeGroups([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 4), [
+                [1, 2, 3, 4],
+                [5, 6, 7, 8],
+                [9, 10, 11],
+                [12, 13, 14],
+            ]);
         });
 
         it('should make the rounds for a round-robin group', () => {
@@ -17,6 +23,17 @@ describe('Helpers', () => {
             assertRoundRobin([1, 2, 3, 4], makeRoundRobinMatches([1, 2, 3, 4]));
             assertRoundRobin([1, 2, 3, 4, 5], makeRoundRobinMatches([1, 2, 3, 4, 5]));
             assertRoundRobin([1, 2, 3, 4, 5, 6], makeRoundRobinMatches([1, 2, 3, 4, 5, 6]));
+        });
+
+        it('should mirror the same round order for a double round-robin group', () => {
+            assert.deepStrictEqual(makeRoundRobinMatches([1, 2, 3, 4], 'double'), [
+                [[1, 4], [3, 2]],
+                [[2, 4], [1, 3]],
+                [[3, 4], [2, 1]],
+                [[4, 1], [2, 3]],
+                [[4, 2], [3, 1]],
+                [[4, 3], [1, 2]],
+            ]);
         });
     });
 
@@ -150,6 +167,15 @@ describe('Helpers', () => {
             ]);
         });
 
+        it('should make a snake ordering for uneven groups', () => {
+            assert.deepStrictEqual(ordering['groups.seed_optimized']([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 4), [
+                1, 8, 9, 14,  // 1st group
+                2, 7, 10, 13, // 2nd group
+                3, 6, 11,     // 3rd group
+                4, 5, 12,     // 4th group
+            ]);
+        });
+
         it('should make a bracket-optimized ordering for groups (8 seeds, 4 groups)', () => {
             const seeds = [1, 2, 3, 4, 5, 6, 7, 8];
             const result = ordering['groups.bracket_optimized'](seeds, 4);
@@ -220,6 +246,15 @@ describe('Helpers', () => {
                 [3, 5, 10, 16],
                 [4, 6, 9, 15],
             ]);
+        });
+
+        it('should make a bracket-optimized ordering for groups without missing seeds', () => {
+            const seeds = Array.from({ length: 14 }, (_, i) => i + 1);
+            const result = ordering['groups.bracket_optimized'](seeds, 4);
+
+            assert.strictEqual(result.length, 14);
+            assert.isFalse(result.includes(undefined));
+            assert.deepStrictEqual(makeGroups(result, 4).map(group => group.length), [4, 4, 3, 3]);
         });
     });
 

--- a/test/round-robin.spec.js
+++ b/test/round-robin.spec.js
@@ -9,6 +9,18 @@ const { Status } = require('brackets-model');
 const storage = new JsonDatabase();
 const manager = new BracketsManager(storage);
 
+const getGroupPositions = async () => {
+    const groups = await storage.select('group');
+
+    return Promise.all(groups.map(async group => {
+        const matches = await storage.select('match', { group_id: group.id });
+        const positions = matches.flatMap(match => [match.opponent1?.position, match.opponent2?.position])
+            .filter(position => typeof position === 'number');
+
+        return [...new Set(positions)].sort((a, b) => a - b);
+    }));
+};
+
 describe('Create a round-robin stage', () => {
 
     beforeEach(() => {
@@ -75,6 +87,28 @@ describe('Create a round-robin stage', () => {
         }
     });
 
+    it('should preserve uneven manual seeding groups', async () => {
+        const manualOrdering = [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11],
+            [12, 13, 14],
+        ];
+
+        await manager.create.stage({
+            name: 'Example',
+            tournamentId: 0,
+            type: 'round_robin',
+            seeding: Array.from({ length: 14 }, (_, i) => `Team ${i + 1}`),
+            settings: {
+                groupCount: 4,
+                manualOrdering,
+            },
+        });
+
+        assert.deepStrictEqual(await getGroupPositions(), manualOrdering);
+    });
+
     it('should throw if manual ordering has invalid counts', async () => {
         await assert.isRejected(manager.create.stage({
             name: 'Example',
@@ -132,6 +166,32 @@ describe('Create a round-robin stage', () => {
 
         // One match must be missing.
         assert.strictEqual((await storage.select('match')).length, 11);
+    });
+
+    it('should balance group sizes when participant count is not divisible by group count', async () => {
+        const seedOrderings = [
+            undefined,
+            'groups.effort_balanced',
+            'groups.seed_optimized',
+            'groups.bracket_optimized',
+        ];
+
+        for (const seedOrdering of seedOrderings) {
+            storage.reset();
+
+            await manager.create.stage({
+                name: 'Example',
+                tournamentId: 0,
+                type: 'round_robin',
+                seeding: Array.from({ length: 14 }, (_, i) => `Team ${i + 1}`),
+                settings: {
+                    groupCount: 4,
+                    ...(seedOrdering ? { seedOrdering: [seedOrdering] } : {}),
+                },
+            });
+
+            assert.deepStrictEqual((await getGroupPositions()).map(group => group.length), [4, 4, 3, 3]);
+        }
     });
 
     it('should create a round-robin stage with to be determined participants', async () => {


### PR DESCRIPTION
Closes #196 and #187

- Fix double round-robin scheduling so the return leg keeps the same round order and swaps home/away sides.
- Balance round-robin group creation for uneven participant counts, including default and seeded group orderings.
- Preserve manual round-robin group shapes instead of flattening and re-chunking them.
- Add regression tests for the double round-robin order and uneven 14-player / 4-group layouts.