### PR TITLE
Keep terminal matches completed instead of archiving them

### DIFF
--- a/src/base/getter.ts
+++ b/src/base/getter.ts
@@ -150,6 +150,9 @@ export class BaseGetter {
      * @param roundNumber Number of the current round.
      */
     private async getPreviousMatchesFinalDoubleElimination(match: Match, roundNumber: number): Promise<Match[]> {
+        if (match.number === 2) // Consolation final
+            return this.getPreviousMatchesConsolationFinalDoubleElimination(match);
+
         if (roundNumber > 1) // Double grand final
             return [await this.findMatch(match.group_id, roundNumber - 1, 1)];
 
@@ -178,6 +181,44 @@ export class BaseGetter {
             throw Error('Match not found.');
 
         return [winnerBracketFinalMatch, loserBracketFinalMatch];
+    }
+
+    /**
+     * Gets the matches leading to the consolation final in a double elimination stage.
+     *
+     * @param match The current match.
+     */
+    private async getPreviousMatchesConsolationFinalDoubleElimination(match: Match): Promise<Match[]> {
+        const loserBracket = await this.getLoserBracket(match.stage_id);
+        if (!loserBracket)
+            throw Error('Loser bracket not found.');
+
+        const lastRound = await this.getLastRound(loserBracket.id);
+        const matches: Match[] = [];
+
+        for (const roundNumber of [lastRound.number - 1, lastRound.number]) {
+            if (roundNumber < 1)
+                continue;
+
+            const round = await this.storage.selectFirst('round', {
+                group_id: loserBracket.id,
+                number: roundNumber,
+            });
+
+            if (!round)
+                throw Error('Round not found.');
+
+            const roundMatches = await this.storage.select('match', {
+                round_id: round.id,
+            });
+
+            if (!roundMatches)
+                throw Error('Error getting loser bracket matches.');
+
+            matches.push(...roundMatches);
+        }
+
+        return matches;
     }
 
     /**

--- a/src/base/updater.ts
+++ b/src/base/updater.ts
@@ -295,11 +295,6 @@ export class BaseUpdater extends BaseGetter {
     protected async updateNext(match: Match, matchLocation: GroupType, stage: Stage, roundNumber: number, roundCount: number): Promise<void> {
         const nextMatches = await this.getNextMatches(match, matchLocation, stage, roundNumber, roundCount);
         if (nextMatches.length === 0) {
-            // Archive match if it doesn't have following matches and is completed.
-            // When the stage is fully complete, all matches should be archived.
-            if (match.status === Status.Completed)
-                await this.archiveMatches([match]);
-
             return;
         }
 

--- a/test/double-elimination.spec.js
+++ b/test/double-elimination.spec.js
@@ -385,7 +385,18 @@ describe('Previous and next match update in double elimination stage', () => {
         });
 
         assert.strictEqual((await storage.select('match', 5)).status, Status.Archived); // Grand final (round 1)
-        assert.strictEqual((await storage.select('match', 6)).status, Status.Archived); // Grand final (round 2)
+        assert.strictEqual((await storage.select('match', 6)).status, Status.Completed); // Grand final (round 2)
+
+        await manager.update.match({
+            id: 6, // Grand Final round 2
+            opponent1: { score: 10 },
+            opponent2: { score: 16, result: 'win' },
+        });
+
+        const grandFinal = await storage.select('match', 6);
+        assert.strictEqual(grandFinal.status, Status.Completed);
+        assert.strictEqual(grandFinal.opponent1.result, 'loss');
+        assert.strictEqual(grandFinal.opponent2.result, 'win');
     });
 
     it('should determine matches in grand final (with consolation final)', async () => {
@@ -467,7 +478,7 @@ describe('Previous and next match update in double elimination stage', () => {
         });
 
         assert.strictEqual((await storage.select('match', 5)).status, Status.Archived); // Grand final (round 1)
-        assert.strictEqual((await storage.select('match', 6)).status, Status.Archived); // Grand final (round 2)
+        assert.strictEqual((await storage.select('match', 6)).status, Status.Completed); // Grand final (round 2)
     });
 
     it('should determine next matches and reset them', async () => {

--- a/test/single-elimination.spec.js
+++ b/test/single-elimination.spec.js
@@ -390,7 +390,7 @@ describe('Previous and next match update in single elimination stage', () => {
         });
 
         assert.strictEqual((await storage.select('match', 2)).status, Status.Running);
-        assert.strictEqual((await storage.select('match', 3)).status, Status.Archived);
+        assert.strictEqual((await storage.select('match', 3)).status, Status.Completed);
 
         await manager.update.match({
             id: 2, // Final
@@ -398,8 +398,93 @@ describe('Previous and next match update in single elimination stage', () => {
             opponent2: { score: 9 },
         });
 
-        assert.strictEqual((await storage.select('match', 2)).status, Status.Archived);
-        assert.strictEqual((await storage.select('match', 3)).status, Status.Archived);
+        assert.strictEqual((await storage.select('match', 2)).status, Status.Completed);
+        assert.strictEqual((await storage.select('match', 3)).status, Status.Completed);
+    });
+
+    it('should keep the final ready when the consolation final is completed first', async () => {
+        await manager.create.stage({
+            name: 'Example',
+            tournamentId: 0,
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+            settings: { consolationFinal: true },
+        });
+
+        await manager.update.match({
+            id: 0, // First match of round 1
+            opponent1: { score: 16, result: 'win' },
+            opponent2: { score: 12 },
+        });
+
+        await manager.update.match({
+            id: 1, // Second match of round 1
+            opponent1: { score: 13 },
+            opponent2: { score: 16, result: 'win' },
+        });
+
+        await manager.update.match({
+            id: 3, // Consolation final
+            opponent1: { score: 16, result: 'win' },
+            opponent2: { score: 9 },
+        });
+
+        assert.strictEqual((await storage.select('match', 2)).status, Status.Ready);
+        assert.strictEqual((await storage.select('match', 3)).status, Status.Completed);
+
+        await manager.update.match({
+            id: 2, // Final
+            opponent1: { score: 16, result: 'win' },
+            opponent2: { score: 9 },
+        });
+
+        assert.strictEqual((await storage.select('match', 2)).status, Status.Completed);
+        assert.strictEqual((await storage.select('match', 3)).status, Status.Completed);
+    });
+
+    it('should keep a completed final editable', async () => {
+        await manager.create.stage({
+            name: 'Example',
+            tournamentId: 0,
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
+        });
+
+        await manager.update.match({
+            id: 0,
+            opponent1: { score: 16, result: 'win' },
+            opponent2: { score: 12 },
+        });
+
+        await manager.update.match({
+            id: 1,
+            opponent1: { score: 13 },
+            opponent2: { score: 16, result: 'win' },
+        });
+
+        await manager.update.match({
+            id: 2,
+            opponent1: { score: 16, result: 'win' },
+            opponent2: { score: 9 },
+        });
+
+        let final = await storage.select('match', 2);
+        assert.strictEqual(final.status, Status.Completed);
+        assert.strictEqual(await manager.get.currentStage(0), null);
+        assert.strictEqual(await manager.get.currentRound(0), null);
+        assert.deepEqual(await manager.get.currentMatches(0), []);
+
+        await manager.update.match({
+            id: 2,
+            opponent1: { score: 14 },
+            opponent2: { score: 16, result: 'win' },
+        });
+
+        final = await storage.select('match', 2);
+        assert.strictEqual(final.status, Status.Completed);
+        assert.strictEqual(final.opponent1.result, 'loss');
+        assert.strictEqual(final.opponent2.result, 'win');
+        assert.strictEqual((await manager.get.finalStandings(0))[0].id, final.opponent2.id);
     });
 
     it('should archive previous matches', async () => {
@@ -438,7 +523,7 @@ describe('Previous and next match update in single elimination stage', () => {
             opponent2: { score: 9 },
         });
 
-        assert.strictEqual((await storage.select('match', 2)).status, Status.Archived); // Final
-        assert.strictEqual((await storage.select('match', 3)).status, Status.Archived); // Consolation final
+        assert.strictEqual((await storage.select('match', 2)).status, Status.Completed); // Final
+        assert.strictEqual((await storage.select('match', 3)).status, Status.Completed); // Consolation final
     });
 });

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -709,7 +709,7 @@ describe('Update match games', () => {
         await manager.update.matchGame({ parent_id: 2, number: 2, opponent1: { result: 'win' } });
 
         finalMatchStatus = (await storage.select('match', 2)).status;
-        assert.strictEqual(finalMatchStatus, Status.Archived);
+        assert.strictEqual(finalMatchStatus, Status.Completed);
         assert.strictEqual(finalMatchStatus, (await storage.select('match_game', 4)).status);
 
         const semi1Status = (await storage.select('match', 0)).status;
@@ -749,6 +749,53 @@ describe('Update match games', () => {
         assert.strictEqual(secondChildReset.status, Status.Running);
         assert.strictEqual(secondChildReset.opponent1.score, 1);
         assert.strictEqual(secondChildReset.opponent2.score, 0);
+    });
+
+    it('should allow correcting child games of a terminal final', async () => {
+        await manager.create.stage({
+            name: 'With match games',
+            tournamentId: 0,
+            type: 'single_elimination',
+            seeding: ['Team 1', 'Team 2'],
+            settings: {
+                matchesChildCount: 3,
+            },
+        });
+
+        await manager.update.matchGame({ id: 0, opponent1: { result: 'win' } });
+        await manager.update.matchGame({ id: 1, opponent1: { result: 'win' } });
+
+        let parent = await storage.select('match', 0);
+        assert.strictEqual(parent.status, Status.Completed);
+        assert.strictEqual(parent.opponent1.result, 'win');
+
+        await manager.update.matchGame({
+            id: 0,
+            opponent1: { score: 21, result: 'win' },
+            opponent2: { score: 19 },
+        });
+
+        let correctedGame = await storage.select('match_game', 0);
+        assert.strictEqual(correctedGame.status, Status.Completed);
+        assert.strictEqual(correctedGame.opponent1.result, 'win');
+        assert.strictEqual(correctedGame.opponent1.score, 21);
+        assert.strictEqual(correctedGame.opponent2.score, 19);
+
+        await manager.update.matchGame({ id: 1, opponent2: { result: 'win' } });
+
+        parent = await storage.select('match', 0);
+        assert.strictEqual(parent.status, Status.Running);
+        assert.notExists(parent.opponent1.result);
+        assert.notExists(parent.opponent2.result);
+        assert.strictEqual(parent.opponent1.score, 1);
+        assert.strictEqual(parent.opponent2.score, 1);
+
+        await manager.update.matchGame({ id: 2, opponent2: { result: 'win' } });
+
+        parent = await storage.select('match', 0);
+        assert.strictEqual(parent.status, Status.Completed);
+        assert.strictEqual(parent.opponent1.result, 'loss');
+        assert.strictEqual(parent.opponent2.result, 'win');
     });
 
     it('should throw if trying to update a locked match game', async () => {
@@ -886,7 +933,7 @@ describe('Update match games', () => {
 
         await manager.update.matchGame({ id: 0, opponent1: { result: 'win' } });
         await manager.update.matchGame({ id: 1, opponent1: { result: 'win' } });
-        assert.strictEqual((await storage.select('match', 0)).status, Status.Archived); // Completed, but single match in the stage.
+        assert.strictEqual((await storage.select('match', 0)).status, Status.Completed);
 
         await manager.reset.matchGameResults(0);
         assert.strictEqual((await storage.select('match', 0)).status, Status.Running);


### PR DESCRIPTION
Closes #205

- Stop auto-archiving terminal elimination matches, so completed finals and grand finals stay `Completed` and remain editable.
- Preserve the existing archive behavior for earlier matches that become historical when a following match starts.
- Add regression coverage for single elimination, double elimination, and match-game updates, including the consolation-final ordering bug.