### PR TITLE
Emit manager events for successful storage mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ await manager.update.match({
 });
 ```
 
+The manager emits events when storage mutation operations succeed:
+
+```js
+manager.on('entity.changed', event => {
+  // Any successful insert, update or delete operation.
+});
+```
+
 Rendered with the [viewer](https://github.com/Drarig29/brackets-viewer.js):
 
 <img width="581" alt="image" src="https://user-images.githubusercontent.com/9317502/232905749-195c4f40-527c-4f17-a639-82f639432ed9.png">

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ export {
     ChildCountLevel,
     ChildGameResults,
     MatchGameCancellationOptions,
+    EntityChangeMethod,
+    EntityChangedEvent,
 } from './types';
 
 export * as helpers from './helpers';

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,5 +1,6 @@
-import { CrudInterface, Database, InputStage, Stage } from 'brackets-model';
-import { Storage } from './types';
+import { EventEmitter } from 'events';
+import { CrudInterface, Database, InputStage, Stage, Table } from 'brackets-model';
+import { EntityChangedEvent, EntityChangeMethod, Storage } from './types';
 import { Create } from './create';
 import { Get } from './get';
 import { Update } from './update';
@@ -19,13 +20,17 @@ export interface CallableCreate extends Create {
     (stage: InputStage): Promise<Stage>
 }
 
-type CrudMethod = (table: string, ...args: unknown[]) => Promise<unknown>;
+type CrudMethod = (table: Table, ...args: unknown[]) => Promise<unknown>;
 type AbstractStorage = Record<string, CrudMethod>;
+
+export interface BracketsManager {
+    on(eventName: 'entity.changed', listener: (event: EntityChangedEvent) => void): this
+}
 
 /**
  * A class to handle tournament management at those levels: `stage`, `group`, `round`, `match` and `match_game`.
  */
-export class BracketsManager {
+export class BracketsManager extends EventEmitter {
 
     public verbose = false;
     public storage: Storage;
@@ -44,6 +49,8 @@ export class BracketsManager {
      * @param verbose Whether to log CRUD operations.
      */
     constructor(storageInterface: CrudInterface, verbose?: boolean) {
+        super();
+
         this.verbose = verbose ?? false;
 
         this.storage = storageInterface as Storage;
@@ -161,37 +168,76 @@ export class BracketsManager {
      */
     private instrumentStorage(): void {
         const storage = this.storage as unknown as AbstractStorage;
-        const instrumentedMethods: Array<keyof CrudInterface> = ['insert', 'select', 'update', 'delete'];
+        const instrumentedMethods = ['insert', 'select', 'update', 'delete'];
 
         for (const method of Object.getOwnPropertyNames(Object.getPrototypeOf(storage))) {
-            if (!(instrumentedMethods as string[]).includes(method))
+            if (!instrumentedMethods.includes(method))
                 continue;
 
             const originalMethod = storage[method].bind(storage);
 
-            storage[method] = async (table: string, ...args: unknown[]): Promise<unknown> => {
+            storage[method] = async (table: Table, ...args: unknown[]): Promise<unknown> => {
                 const verbose = this.verbose;
-                let id: string;
-                let start: number;
+                const mutationMethod = isStorageMutation(method) ? method : undefined;
+                const shouldEmit = mutationMethod !== undefined && this.listenerCount('entity.changed') > 0;
+                const shouldTrack = verbose || shouldEmit;
+                let id: string | undefined;
+                let start: number | undefined;
 
-                if (verbose) {
+                if (shouldTrack) {
                     id = uuidv4();
                     start = Date.now();
-                    console.log(`${id} ${method.toUpperCase()} "${table}" args: ${JSON.stringify(args)}`);
                 }
+
+                if (verbose)
+                    console.log(`${id!} ${method.toUpperCase()} "${table}" args: ${JSON.stringify(args)}`);
 
                 const result = await originalMethod(table, ...args);
 
-                if (verbose) {
-                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+                if (shouldTrack) {
                     const duration = Date.now() - start!;
 
-                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-                    console.log(`${id!} ${duration}ms - Returned ${JSON.stringify(result)}`);
+                    if (shouldEmit && isSuccessfulStorageMutation(mutationMethod, result))
+                        emitStorageMutationEvent(this, { id: id!, method: mutationMethod, table, args, result, duration });
+
+                    if (verbose)
+                        console.log(`${id!} ${duration}ms - Returned ${JSON.stringify(result)}`);
                 }
 
                 return result;
             };
         }
     }
+}
+
+/**
+ * Emits a storage mutation through the public manager events.
+ *
+ * @param manager Brackets manager.
+ * @param event Storage mutation event.
+ */
+function emitStorageMutationEvent(manager: BracketsManager, event: EntityChangedEvent): void {
+    manager.emit('entity.changed', event);
+}
+
+/**
+ * Checks whether a storage mutation succeeded.
+ *
+ * @param method Storage method.
+ * @param result Storage method result.
+ */
+function isSuccessfulStorageMutation(method: EntityChangeMethod, result: unknown): boolean {
+    if (method === 'insert')
+        return result !== false && result !== -1;
+
+    return result === true;
+}
+
+/**
+ * Checks whether a storage method mutates entities.
+ *
+ * @param method Storage method.
+ */
+function isStorageMutation(method: string): method is EntityChangeMethod {
+    return method === 'insert' || method === 'update' || method === 'delete';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,23 @@ export type DeepPartial<T> = T extends object ? {
 } : T;
 
 /**
+ * The storage methods which can mutate entities.
+ */
+export type EntityChangeMethod = 'insert' | 'update' | 'delete';
+
+/**
+ * An event emitted after a storage mutation succeeds.
+ */
+export interface EntityChangedEvent<T extends Table = Table> {
+    id: string,
+    method: EntityChangeMethod,
+    table: T,
+    args: unknown[],
+    result: unknown,
+    duration: number,
+}
+
+/**
  * An item in the final standings of an elimination stage. Each item represents a participant.
  */
 export interface FinalStandingsItem {

--- a/test/events.spec.js
+++ b/test/events.spec.js
@@ -1,0 +1,241 @@
+const assert = require('chai').assert;
+const { Status } = require('brackets-model');
+const { InMemoryDatabase } = require('brackets-memory-db');
+const { BracketsManager } = require('../dist');
+
+const emptyData = {
+    participant: [],
+    stage: [],
+    group: [],
+    round: [],
+    match: [],
+    match_game: [],
+};
+
+const stage = {
+    id: 0,
+    tournament_id: 0,
+    name: 'Event stage',
+    type: 'round_robin',
+    number: 1,
+    settings: { size: 2 },
+};
+
+const match = {
+    id: 0,
+    stage_id: 0,
+    group_id: 0,
+    round_id: 0,
+    number: 1,
+    child_count: 0,
+    status: Status.Ready,
+    opponent1: { id: 0 },
+    opponent2: { id: 1 },
+};
+
+/**
+ * Creates a manager backed by in-memory test data.
+ *
+ * @param data Data to put in storage.
+ */
+function makeManager(data = {}) {
+    const storage = new InMemoryDatabase();
+    storage.setData({
+        ...emptyData,
+        ...data,
+    });
+
+    return new BracketsManager(storage);
+}
+
+/**
+ * Normalizes generated event metadata for stable assertions.
+ *
+ * @param events Events to normalize.
+ */
+function normalizeEvents(events) {
+    return events.map(({ id, duration, ...event }) => ({
+        id: typeof id,
+        ...event,
+        duration: typeof duration,
+    }));
+}
+
+describe('Events', () => {
+    it('should emit entity.changed when a match update succeeds', async () => {
+        const manager = makeManager({ stage: [stage], match: [match] });
+        const entityEvents = [];
+
+        manager.on('entity.changed', event => entityEvents.push(event));
+
+        await manager.update.match({
+            id: 0,
+            opponent1: { score: 1 },
+            opponent2: { score: 0 },
+        });
+
+        assert.deepEqual(normalizeEvents(entityEvents), [{
+            id: 'string',
+            method: 'update',
+            table: 'match',
+            args: [
+                0,
+                {
+                    ...match,
+                    status: Status.Running,
+                    opponent1: { id: 0, score: 1 },
+                    opponent2: { id: 1, score: 0 },
+                },
+            ],
+            result: true,
+            duration: 'number',
+        }]);
+    });
+
+    it('should emit entity.changed for match game and parent match updates', async () => {
+        const manager = makeManager({
+            stage: [stage],
+            match: [{ ...match, child_count: 1 }],
+            match_game: [{
+                id: 0,
+                stage_id: 0,
+                parent_id: 0,
+                number: 1,
+                status: Status.Ready,
+                opponent1: { id: 0 },
+                opponent2: { id: 1 },
+            }],
+        });
+        const entityEvents = [];
+
+        manager.on('entity.changed', event => entityEvents.push(event));
+
+        await manager.update.matchGame({
+            id: 0,
+            opponent1: { result: 'win' },
+        });
+
+        assert.deepEqual(normalizeEvents(entityEvents), [
+            {
+                id: 'string',
+                method: 'update',
+                table: 'match_game',
+                args: [
+                    0,
+                    {
+                        id: 0,
+                        stage_id: 0,
+                        parent_id: 0,
+                        number: 1,
+                        status: Status.Completed,
+                        opponent1: { id: 0, result: 'win' },
+                        opponent2: { id: 1, result: 'loss' },
+                    },
+                ],
+                result: true,
+                duration: 'number',
+            },
+            {
+                id: 'string',
+                method: 'update',
+                table: 'match',
+                args: [
+                    0,
+                    {
+                        ...match,
+                        child_count: 1,
+                        status: Status.Completed,
+                        opponent1: { id: 0, score: 1, result: 'win' },
+                        opponent2: { id: 1, score: 0, result: 'loss' },
+                    },
+                ],
+                result: true,
+                duration: 'number',
+            },
+            {
+                id: 'string',
+                method: 'update',
+                table: 'match_game',
+                args: [
+                    { parent_id: 0 },
+                    {
+                        opponent1: { id: 0 },
+                        opponent2: { id: 1 },
+                    },
+                ],
+                result: true,
+                duration: 'number',
+            },
+        ]);
+    });
+
+    it('should emit when a storage update succeeds without comparing data', async () => {
+        const manager = makeManager({ stage: [stage], match: [match] });
+        const entityEvents = [];
+
+        manager.on('entity.changed', event => entityEvents.push(event));
+
+        await manager.update.match({ id: 0 });
+
+        assert.deepEqual(normalizeEvents(entityEvents), [{
+            id: 'string',
+            method: 'update',
+            table: 'match',
+            args: [0, match],
+            result: true,
+            duration: 'number',
+        }]);
+    });
+
+    it('should emit one event for a successful bulk update operation', async () => {
+        const manager = makeManager({
+            match: [
+                { ...match, id: 0 },
+                { ...match, id: 1 },
+            ],
+        });
+        const entityEvents = [];
+
+        manager.on('entity.changed', event => entityEvents.push(event));
+
+        await manager.storage.update('match', { stage_id: 0 }, { child_count: 1 });
+
+        assert.deepEqual(normalizeEvents(entityEvents), [{
+            id: 'string',
+            method: 'update',
+            table: 'match',
+            args: [{ stage_id: 0 }, { child_count: 1 }],
+            result: true,
+            duration: 'number',
+        }]);
+    });
+
+    it('should emit entity.changed when insert and delete operations succeed', async () => {
+        const manager = makeManager();
+        const entityEvents = [];
+
+        manager.on('entity.changed', event => entityEvents.push(event));
+
+        const id = await manager.storage.insert('participant', { tournament_id: 0, name: 'Team 1' });
+        await manager.storage.delete('participant', { id });
+
+        assert.deepEqual(normalizeEvents(entityEvents), [
+            {
+                id: 'string',
+                method: 'insert',
+                table: 'participant',
+                args: [{ tournament_id: 0, name: 'Team 1' }],
+                result: 0,
+                duration: 'number',
+            },
+            {
+                id: 'string',
+                method: 'delete',
+                table: 'participant',
+                args: [{ id: 0 }],
+                result: true,
+                duration: 'number',
+            },
+        ]);
+    });
+});


### PR DESCRIPTION
Closes #224 

- Make `BracketsManager` emit `entity.changed` events after successful storage inserts, updates, and deletes.
- Expose the new `EntityChangeMethod` and `EntityChangedEvent` types from the public entrypoint.
- Document the new event in the README.
- Add coverage for update, bulk update, insert, delete, and parent/child match update flows.